### PR TITLE
Add Carla environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Vscode
 .vscode/
 .DS_Store
+.idea
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Composable benchmark for intelligent agents. The design can support
 ### Model
 The model module contains structured differentiable functions that either represent system dynamics or control policies.
 The model can be analytical (i.e., ODEs, basis functions) or numerical (i.e., neural networks).
-For now, we implemented analytical models for system dyanmics, which are encoded symbolically. 
+For now, we implemented analytical models for system dynamics, which are encoded symbolically. 
 Both linear/nonlinear systems are supported.
 
 ### Planner
@@ -35,13 +35,13 @@ The python version is 3.8. But the code should be compatible with all 3.x versio
 We specified the dependencies in `env.yml`. You can reproduce the conda environment by
 
 ```bash
-conda env create --name $your_env_name -f env.yml
+conda env create --name $your_env_name -f environment.yml
 ```
 
 If you already have an environment and just want to make sure existing packages align with the specification. Run
 
 ```bash
-conda env update --name $your_env_name -f env.yml
+conda env update --name $your_env_name -f environment.yml
 ```
 
 If you want to use the Mujoco env. Install mujoco_py with

--- a/README.md
+++ b/README.md
@@ -49,7 +49,20 @@ If you want to use the Mujoco env. Install mujoco_py with
 pip install mujoco_py==2.0.2.8
 ```
 
+To use Carla, you'll need to run a headless simulator beforehand and add the python module to your `PYTHONPATH`.
+See the [carla package installation docs][carla-install-doc] to download a package release.
+
+
+```bash
+# See https://carla.readthedocs.io/en/latest/build_docker/ for more info
+docker run --rm -p 2000-2002:2000-2002 -it --gpus all --name carla_sim carlasim/carla:0.9.6 ./CarlaUE4.sh -opengl
+# Make sure the carla python module is available to python3
+export PYTHONPATH=$PYTHONPATH:<path_to_carla_package>/PythonAPI/carla/dist/carla-0.9.6-py3.5-linux-x86_64.egg
+```
+
 ## Usage
 
 See [examples](https://github.com/intelligent-control-lab/Benchmark/tree/master/examples) for more information.
 
+
+[carla-install-doc]: https://carla.readthedocs.io/en/latest/start_quickstart/#b-package-installation

--- a/env/carla_env.py
+++ b/env/carla_env.py
@@ -1,0 +1,25 @@
+from env.carla_world import CarlaWorld
+
+
+class CarlaEnv:
+    """Interface to the Carla World"""
+    def __init__(self, env_spec, comp_agents):
+        self.dt = env_spec['dt']
+        self.env_spec = env_spec
+        self.comp_agents = comp_agents
+        self.world = CarlaWorld(env_spec["world"]["spec"])
+
+    def reset(self):
+        self.world.reset()
+        env_info, sensor_data = self.world.measure()
+        return self.dt, env_info, sensor_data
+
+    def step(self, actions, render=True):
+        self.world.simulate(actions, self.dt)
+        env_info, sensor_data = self.world.measure()
+        if render:
+            self.render(env_info)
+        return self.dt, env_info, sensor_data
+
+    def render(self, env_info):
+        self.world.render()

--- a/env/carla_world/__init__.py
+++ b/env/carla_world/__init__.py
@@ -1,0 +1,1 @@
+from .world import CarlaWorld

--- a/env/carla_world/camera_manager.py
+++ b/env/carla_world/camera_manager.py
@@ -1,0 +1,111 @@
+import weakref
+
+import carla
+from carla import ColorConverter
+import numpy as np
+import pygame
+
+
+class CameraManager(object):
+    """Helper class for a camera to track ego vehicle"""
+    def __init__(self, parent_actor, hud, gamma_correction):
+        self.sensor = None
+        self.surface = None
+        self._parent = parent_actor
+        self.hud = hud
+        self.recording = False
+        bound_y = 0.5 + self._parent.bounding_box.extent.y
+        attachment = carla.AttachmentType
+        self._camera_transforms = [
+            (carla.Transform(carla.Location(x=-5.5, z=2.5), carla.Rotation(pitch=8.0)), attachment.SpringArm),
+            (carla.Transform(carla.Location(x=1.6, z=1.7)), attachment.Rigid),
+            (carla.Transform(carla.Location(x=5.5, y=1.5, z=1.5)), attachment.SpringArm),
+            (carla.Transform(carla.Location(x=-8.0, z=6.0), carla.Rotation(pitch=6.0)), attachment.SpringArm),
+            (carla.Transform(carla.Location(x=-1, y=-bound_y, z=0.5)), attachment.Rigid)]
+        self.transform_index = 1
+        self.sensors = [
+            ['sensor.camera.rgb', ColorConverter.Raw, 'Camera RGB'],
+            ['sensor.camera.depth', ColorConverter.Raw, 'Camera Depth (Raw)'],
+            ['sensor.camera.depth', ColorConverter.Depth, 'Camera Depth (Gray Scale)'],
+            ['sensor.camera.depth', ColorConverter.LogarithmicDepth, 'Camera Depth (Logarithmic Gray Scale)'],
+            ['sensor.camera.semantic_segmentation', ColorConverter.Raw, 'Camera Semantic Segmentation (Raw)'],
+            ['sensor.camera.semantic_segmentation', ColorConverter.CityScapesPalette,
+                'Camera Semantic Segmentation (CityScapes Palette)'],
+            ['sensor.lidar.ray_cast', None, 'Lidar (Ray-Cast)']]
+        world = self._parent.get_world()
+        bp_library = world.get_blueprint_library()
+        for item in self.sensors:
+            bp = bp_library.find(item[0])
+            if item[0].startswith('sensor.camera'):
+                bp.set_attribute('image_size_x', str(hud.dim[0]))
+                bp.set_attribute('image_size_y', str(hud.dim[1]))
+                if bp.has_attribute('gamma'):
+                    bp.set_attribute('gamma', str(gamma_correction))
+            elif item[0].startswith('sensor.lidar'):
+                bp.set_attribute('range', '5000')
+            item.append(bp)
+        self.index = None
+
+    def toggle_camera(self):
+        self.transform_index = (self.transform_index + 1) % len(self._camera_transforms)
+        self.set_sensor(self.index, notify=False, force_respawn=True)
+
+    def set_sensor(self, index, notify=True, force_respawn=False):
+        index = index % len(self.sensors)
+        needs_respawn = True if self.index is None else \
+            (force_respawn or (self.sensors[index][0] != self.sensors[self.index][0]))
+        if needs_respawn:
+            if self.sensor is not None:
+                self.sensor.destroy()
+                self.surface = None
+            self.sensor = self._parent.get_world().spawn_actor(
+                self.sensors[index][-1],
+                self._camera_transforms[self.transform_index][0],
+                attach_to=self._parent,
+                attachment_type=self._camera_transforms[self.transform_index][1])
+            # We need to pass the lambda a weak reference to self to avoid
+            # circular reference.
+            weak_self = weakref.ref(self)
+            self.sensor.listen(lambda image: CameraManager._parse_image(weak_self, image))
+        if notify:
+            self.hud.notification(self.sensors[index][2])
+        self.index = index
+
+    def next_sensor(self):
+        self.set_sensor(self.index + 1)
+
+    def toggle_recording(self):
+        self.recording = not self.recording
+        self.hud.notification('Recording %s' % ('On' if self.recording else 'Off'))
+
+    def render(self, display):
+        if self.surface is not None:
+            display.blit(self.surface, (0, 0))
+
+    @staticmethod
+    def _parse_image(weak_self, image):
+        self = weak_self()
+        if not self:
+            return
+        if self.sensors[self.index][0].startswith('sensor.lidar'):
+            points = np.frombuffer(image.raw_data, dtype=np.dtype('f4'))
+            points = np.reshape(points, (int(points.shape[0] / 3), 3))
+            lidar_data = np.array(points[:, :2])
+            lidar_data *= min(self.hud.dim) / 100.0
+            lidar_data += (0.5 * self.hud.dim[0], 0.5 * self.hud.dim[1])
+            lidar_data = np.fabs(lidar_data)  # pylint: disable=E1111
+            lidar_data = lidar_data.astype(np.int32)
+            lidar_data = np.reshape(lidar_data, (-1, 2))
+            lidar_img_size = (self.hud.dim[0], self.hud.dim[1], 3)
+            lidar_img = np.zeros(lidar_img_size, dtype=int)
+            lidar_img[tuple(lidar_data.T)] = (255, 255, 255)
+            self.surface = pygame.surfarray.make_surface(lidar_img)
+        else:
+            image.convert(self.sensors[self.index][1])
+            array = np.frombuffer(image.raw_data, dtype=np.dtype("uint8"))
+            array = np.reshape(array, (image.height, image.width, 4))
+            array = array[:, :, :3]
+            array = array[:, :, ::-1]
+            self.surface = pygame.surfarray.make_surface(array.swapaxes(0, 1))
+        if self.recording:
+            image.save_to_disk('_out/%08d' % image.frame)

--- a/env/carla_world/hud.py
+++ b/env/carla_world/hud.py
@@ -1,0 +1,63 @@
+import pygame
+
+
+class HUD(object):
+    """Helper class for a heads up display"""
+    def __init__(self, width, height):
+        self.dim = (width, height)
+        fonts = [x for x in pygame.font.get_fonts() if 'mono' in x]
+        default_font = 'ubuntumono'
+        mono = default_font if default_font in fonts else fonts[0]
+        mono = pygame.font.match_font(mono)
+        self._font_mono = pygame.font.Font(mono, 14)
+        self.server_fps = 0
+        self.frame = 0
+        self.simulation_time = 0
+        self._show_info = True
+        self._info_text = []
+        self._server_clock = pygame.time.Clock()
+
+    def on_world_tick(self, timestamp):
+        self._server_clock.tick()
+        self.server_fps = self._server_clock.get_fps()
+        self.frame = timestamp.frame
+        self.simulation_time = timestamp.elapsed_seconds
+
+    def toggle_info(self):
+        self._show_info = not self._show_info
+
+    def render(self, display):
+        if self._show_info:
+            info_surface = pygame.Surface((220, self.dim[1]))
+            info_surface.set_alpha(100)
+            display.blit(info_surface, (0, 0))
+            v_offset = 4
+            bar_h_offset = 100
+            bar_width = 106
+            for item in self._info_text:
+                if v_offset + 18 > self.dim[1]:
+                    break
+                if isinstance(item, list):
+                    if len(item) > 1:
+                        points = [(x + 8, v_offset + 8 + (1.0 - y) * 30) for x, y in enumerate(item)]
+                        pygame.draw.lines(display, (255, 136, 0), False, points, 2)
+                    item = None
+                    v_offset += 18
+                elif isinstance(item, tuple):
+                    if isinstance(item[1], bool):
+                        rect = pygame.Rect((bar_h_offset, v_offset + 8), (6, 6))
+                        pygame.draw.rect(display, (255, 255, 255), rect, 0 if item[1] else 1)
+                    else:
+                        rect_border = pygame.Rect((bar_h_offset, v_offset + 8), (bar_width, 6))
+                        pygame.draw.rect(display, (255, 255, 255), rect_border, 1)
+                        f = (item[1] - item[2]) / (item[3] - item[2])
+                        if item[2] < 0.0:
+                            rect = pygame.Rect((bar_h_offset + f * (bar_width - 6), v_offset + 8), (6, 6))
+                        else:
+                            rect = pygame.Rect((bar_h_offset, v_offset + 8), (f * bar_width, 6))
+                        pygame.draw.rect(display, (255, 255, 255), rect)
+                    item = item[0]
+                if item:  # At this point has to be a str.
+                    surface = self._font_mono.render(item, True, (255, 255, 255))
+                    display.blit(surface, (8, v_offset))
+                v_offset += 18

--- a/env/carla_world/world.py
+++ b/env/carla_world/world.py
@@ -138,6 +138,9 @@ class CarlaWorld(World):
 
         return False
 
+    def measure(self):
+        return None, self.ego.get_transform()
+
     def reset(self):
         """Reset the environment."""
         # TODO(piraka9011) Return sensor observations

--- a/env/carla_world/world.py
+++ b/env/carla_world/world.py
@@ -1,0 +1,218 @@
+import random
+
+import carla
+import numpy as np
+from progressbar import progressbar
+import pygame
+
+from env.base_world.world import World
+from env.carla_world.hud import HUD
+from env.carla_world.camera_manager import CameraManager
+
+
+class CarlaWorld(World):
+    def __init__(self, spec, render_window=True):
+        super(CarlaWorld, self).__init__(spec)
+        self.recording_enabled = False
+        self.recording_start = 0
+
+        # Carla Client setup
+        client = carla.Client('127.0.0.1', 2000)
+        client.set_timeout(5.0)
+        self.world = client.load_world(spec.get('world', 'Town01'))
+        self.settings = self.world.get_settings()
+        self._set_timestep(0.1)
+        self.map = self.world.get_map()
+
+        # Rendering setup
+        self.clock = None
+        self.camera_manager = None  # Camera tracking ego vehicle
+        self.display = None
+        self.hud = None
+        self.display_resolution = (1280, 720)
+        self._render_window = render_window
+        if self._render_window:
+            self._setup_display()
+
+        # Ego vehicle setup
+        self.ego = None
+        self.ego_bp = self._create_vehicle_blueprint(spec.get('ego_vehicle_filter', 'vehicle.*'), color='49,8,8')
+
+        self.reset()
+
+    def _setup_display(self):
+        """Setup pygame display for rendering."""
+        pygame.init()
+        pygame.font.init()
+        self.display = pygame.display.set_mode(self.display_resolution, pygame.HWSURFACE | pygame.DOUBLEBUF)
+        self.hud = HUD(*self.display_resolution)
+        self.clock = pygame.time.Clock()
+        self.world.on_tick(self.hud.on_world_tick)
+
+    def _set_timestep(self, timestep):
+        """Set and clamp timestep if necessary."""
+        self.settings.fixed_delta_seconds = timestep
+        if self.settings.fixed_delta_seconds > 0.1:
+            print('Carla should not use a timestep greater than 0.1. Clamping timestep')
+            print('See https://github.com/carla-simulator/carla/issues/695 for more info')
+            self.settings.fixed_delta_seconds = 0.1
+        self.world.apply_settings(self.settings)
+
+    def _create_vehicle_blueprint(self, actor_filter, color=None, number_of_wheels=4):
+        """Create the blueprint for a specific actor type.
+        See https://carla.readthedocs.io/en/latest/bp_library/#vehicle
+
+        Args:
+          actor_filter: a string indicating the actor type, e.g, 'vehicle.lincoln*'.
+          color: vehicle color
+          number_of_wheels: limit vehicles by number of wheels
+        Returns:
+          bp: the blueprint object of carla.
+        """
+        blueprints = self.world.get_blueprint_library().filter(actor_filter)
+        blueprint_library = []
+        blueprint_library += [
+            x for x in blueprints if int(x.get_attribute('number_of_wheels')) == number_of_wheels
+        ]
+        bp = random.choice(blueprint_library)
+        if bp.has_attribute('color'):
+            if not color:
+                color = random.choice(bp.get_attribute('color').recommended_values)
+            bp.set_attribute('color', color)
+        return bp
+
+    def _get_actor_polygons(self, f):
+        """Get the bounding box polygon of actors.
+        Args:
+          f: the filter indicating what type of actors we'll look at.
+        Returns:
+          actor_poly_dict: a dictionary containing the bounding boxes of specific actors.
+        """
+        actor_poly_dict = {}
+        for actor in self.world.get_actors().filter(f):
+            # Get x, y and yaw of the actor
+            trans = actor.get_transform()
+            x = trans.location.x
+            y = trans.location.y
+            yaw = trans.rotation.yaw / 180 * np.pi
+            # Get length and width
+            bb = actor.bounding_box
+            length = bb.extent.x
+            width = bb.extent.y
+            # Get bounding box polygon in the actor's local coordinate
+            poly_local = np.array([[length, width], [length, -width], [-length, -width], [-length, width]]).transpose()
+            # Get rotation matrix to transform to global coordinate
+            rotation = np.array([[np.cos(yaw), -np.sin(yaw)], [np.sin(yaw), np.cos(yaw)]])
+            # Get global bounding box polygon
+            poly = np.matmul(rotation, poly_local).transpose() + np.repeat([[x, y]], 4, axis=0)
+            actor_poly_dict[actor.id] = poly
+        return actor_poly_dict
+
+    def _try_spawn_ego_vehicle_at(self, transform):
+        """Try to spawn the ego vehicle at a specific transform.
+        Args:
+          transform: the Carla transform object.
+        Returns:
+          Bool indicating whether the spawn is successful.
+        """
+        vehicle = None
+        # Check if ego position overlaps with surrounding vehicles
+        overlap = False
+        vehicle_polygons = self._get_actor_polygons('vehicle.*')
+        for poly in vehicle_polygons.items():
+            poly_center = np.mean(poly, axis=0)
+            ego_center = np.array([transform.location.x, transform.location.y])
+            dis = np.linalg.norm(poly_center - ego_center)
+            if dis > 8:
+                continue
+            else:
+                overlap = True
+                break
+
+        if not overlap:
+            vehicle = self.world.try_spawn_actor(self.ego_bp, transform)
+
+        if vehicle is not None:
+            self.ego = vehicle
+            return True
+
+        return False
+
+    def reset(self):
+        """Reset the environment."""
+        # TODO(piraka9011) Return sensor observations
+        # Keep same camera config if the camera manager exists.
+        cam_index = self.camera_manager.index if self.camera_manager is not None else 0
+        cam_pos_index = self.camera_manager.transform_index if self.camera_manager is not None else 0
+        # Spawn the ego vehicle
+        if self.ego is not None:
+            spawn_point = self.ego.get_transform()
+            spawn_point.location.z += 2.0
+            spawn_point.rotation.roll = 0.0
+            spawn_point.rotation.pitch = 0.0
+            self.destroy()
+            self.ego = self.world.try_spawn_actor(self.ego_bp, spawn_point)
+        while self.ego is None:
+            spawn_points = self.map.get_spawn_points()
+            spawn_point = random.choice(spawn_points) if spawn_points else carla.Transform()
+            self.ego = self.world.try_spawn_actor(self.ego_bp, spawn_point)
+        # Set up the sensors.
+        self.camera_manager = CameraManager(self.ego, self.hud, 2.2)
+        self.camera_manager.transform_index = cam_pos_index
+        self.camera_manager.set_sensor(cam_index, notify=False)
+
+    def set_render_window(self, render_window):
+        self._render_window = render_window
+
+    def render(self):
+        self.camera_manager.render(self.display)
+        pygame.display.flip()
+
+    def _destroy_camera_manager(self):
+        if self.camera_manager is not None:
+            self.camera_manager.sensor.destroy()
+            self.camera_manager.sensor = None
+            self.camera_manager.index = None
+
+    def destroy(self):
+        """Destroy all known actors and agents."""
+        self._destroy_camera_manager()
+        # TODO(piraka9011) Destroy all added agents
+        actors = [self.ego]
+        for actor in actors:
+            if actor is not None:
+                actor.destroy()
+
+    def simulate(self, actions, dt=0.1):
+        self._set_timestep(dt)
+        acceleration = actions[0]
+        steer = actions[1]
+        # Convert acceleration to throttle and brake
+        if acceleration > 0:
+            throttle = np.clip(acceleration, 0, 1)
+            brake = 0
+        else:
+            throttle = 0
+            brake = np.clip(-acceleration, 0, 1)
+
+        # Apply control
+        act = carla.VehicleControl(throttle=float(throttle), steer=float(-steer), brake=float(brake))
+        self.ego.apply_control(act)
+
+        if self._render_window:
+            self.render()
+
+
+def main():
+    carla_world_spec = {
+        "world": "Town01",
+        "dt": 0.1
+    }
+    carla_env = CarlaWorld(carla_world_spec)
+    actions = [0.2, 0.0]
+    for _ in progressbar(range(200)):
+        carla_env.simulate(actions)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary 

Initial setup for Carla environment.

It only supports executing actions at this time.
Will be extended to add more agents. 

Mostly inspired by the official Carla [`manual_control.py` example](https://github.com/carla-simulator/carla/blob/dev/PythonAPI/examples/manual_control.py).

## Testing

```sh
# Run carla headless
docker run --rm -p 2000-2002:2000-2002 -it --gpus all --name carla_sim carlasim/carla:0.9.6 ./CarlaUE4.sh -opengl
# Make sure the carla python module is available to python3
export PYTHONPATH=$PYTHONPATH:<path_to_carla_package>/PythonAPI/carla/dist/carla-0.9.6-py3.5-linux-x86_64.egg
python env/carla_world/world.py
```